### PR TITLE
python script to extract signal data

### DIFF
--- a/fast5_extract.py
+++ b/fast5_extract.py
@@ -8,7 +8,7 @@ def main():
     args = get_args()
     if args.file:
         for filename in args.file:
-            extract_signal(args.file)
+            extract_signal(filename)
     else:
         for filename in glob.iglob(args.dir + '**/*.fast5', recursive=args.recursive):
             extract_signal(filename)

--- a/fast5_extract.py
+++ b/fast5_extract.py
@@ -1,0 +1,47 @@
+from ont_fast5_api.fast5_file import Fast5File
+from argparse import ArgumentParser
+import sys
+import glob
+
+
+def main():
+    args = get_args()
+    if args.file:
+        for filename in args.file:
+            extract_signal(args.file)
+    else:
+        for filename in glob.iglob(args.dir + '**/*.fast5', recursive=args.recursive):
+            extract_signal(filename)
+
+
+def extract_signal(fn):
+    """
+    Extract raw data from the fast5 file.
+    Important parameter could be scale
+    If True, returns scaled floating point values in pA
+    if False, returns raw DAQ values as 16 bit integers
+    """
+    f = Fast5File(fn, "r")
+    print("{}\t{}".format(fn,
+                          ','.join([str(i) for i in list(f.get_raw_data(scale=False))])))
+
+
+def get_args():
+    parser = ArgumentParser(description="Extract signal level from fast5 files")
+    parser.add_argument("-d", "--dir", help="directory with fast5 file(s) to extract signal from")
+    parser.add_argument("-f", "--file", help="fast5 file(s) to extract signal from", nargs='*')
+    parser.add_argument("-r", "--recursive",
+                        help="recursively go through directories",
+                        action="store_true")
+    args = parser.parse_args()
+    if not args.dir and not args.file:
+        sys.exit("ARGUMENT ERROR: Exactly one of --dir or --file is required")
+    if args.dir and args.file:
+        sys.exit("ARGUMENT ERROR: Exactly one of --dir or --file is required")
+    if args.recursive and args.file:
+        sys.exit("ARGUMENT ERROR: -r/--recursive is only applicable when selecting a directory")
+    return args
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
Adding the first version of a python script to extract signal level data using the ont_fast5_api

usage:
```
fast5_extract.py [-h] [-d DIR] [-f [FILE [FILE ...]]] [-r]

Extract signal level from fast5 files

optional arguments:
  -h, --help            show this help message and exit
  -d DIR, --dir DIR     directory with fast5 file(s) to extract signal from
  -f [FILE [FILE ...]], --file [FILE [FILE ...]]
                        fast5 file(s) to extract signal from
  -r, --recursive       recursively go through directories
```

Either supply a directory of fast5 files using -d/--dir, searched optionally recursive with -r/--recursive OR supply on or more fast5 files with -f/--file

Output is:
`path-to-fast5 \t signal,signal,signal,...`

Dependency:
- only ont_fast5_api
- probably requires Python 3